### PR TITLE
Fix code scanning alert no. 12: Disabling certificate validation

### DIFF
--- a/test/integration/int_cybersource_sfra/googlePay/submitGooglePay.js
+++ b/test/integration/int_cybersource_sfra/googlePay/submitGooglePay.js
@@ -19,7 +19,7 @@ function addProductAndSubmitPayment(creditCard) {
 	var myRequest = {
 		url: config.baseUrl + addProd,
 		method: 'POST',
-		rejectUnauthorized: false,
+		rejectUnauthorized: true,
 		resolveWithFullResponse: true,
 		jar: cookieJar,
 		headers: {


### PR DESCRIPTION
Fixes [https://github.com/CyberSource/cybersource-plugins-salesforceb2ccommerce/security/code-scanning/12](https://github.com/CyberSource/cybersource-plugins-salesforceb2ccommerce/security/code-scanning/12)

To fix the problem, we should ensure that certificate validation is not disabled. This can be achieved by removing the `rejectUnauthorized: false` option or setting it to `true`. This change will enforce certificate validation, ensuring that the connection is secure. 

- **General Fix:** Ensure that the `rejectUnauthorized` option is either removed or explicitly set to `true` to maintain secure TLS connections.
- **Detailed Fix:** In the file `test/integration/int_cybersource_sfra/googlePay/submitGooglePay.js`, locate the `myRequest` object and modify the `rejectUnauthorized` property to `true`.
- **Specific Changes:** Modify line 22 to set `rejectUnauthorized: true`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
