### PR TITLE
Fix code scanning alert no. 10: Disabling certificate validation

### DIFF
--- a/test/integration/int_cybersource_sfra/checkout/submitBillingForm.js
+++ b/test/integration/int_cybersource_sfra/checkout/submitBillingForm.js
@@ -19,7 +19,7 @@ function addProductAndSubmitPayment(creditCard) {
     var myRequest = {
         url: config.baseUrl + addProd,
         method: 'POST',
-        rejectUnauthorized: false,
+        rejectUnauthorized: true,
         resolveWithFullResponse: true,
         jar: cookieJar,
         headers: {


### PR DESCRIPTION
Fixes [https://github.com/CyberSource/cybersource-plugins-salesforceb2ccommerce/security/code-scanning/10](https://github.com/CyberSource/cybersource-plugins-salesforceb2ccommerce/security/code-scanning/10)

To fix the problem, we should ensure that certificate validation is enabled by setting `rejectUnauthorized` to `true`. This change will ensure that the application only accepts valid certificates, thus maintaining the security of the TLS connection. 

In the file `test/integration/int_cybersource_sfra/checkout/submitBillingForm.js`, locate the `myRequest` object and change the `rejectUnauthorized` property from `false` to `true`. This will ensure that the request will only proceed if the server's certificate is valid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
